### PR TITLE
hdhomerun: Add HDHomeRun server support for LiveTV only (#4461)

### DIFF
--- a/configure
+++ b/configure
@@ -28,6 +28,7 @@ OPTIONS=(
   "satip_server:yes"
   "satip_client:yes"
   "hdhomerun_client:no"
+  "hdhomerun_server:yes"
   "hdhomerun_static:yes"
   "iptv:yes"
   "tsfile:yes"

--- a/docs/property/config_hdhomerun_server_username.md
+++ b/docs/property/config_hdhomerun_server_username.md
@@ -1,0 +1,23 @@
+Tvheadend can pretend to be an HDHomeRun device.
+This is only available if Tvheadend has been compiled
+with the feature enabled.
+
+This is currently an experimental feature.  It may
+be withdrawn in the future.
+
+This allows some media players to be able to access
+Live TV channels.  Some other media players use a
+different technique to access HDHomeRun so will not
+be able to play Live TV channels.
+
+On the media player, autodetect of devices will not work.
+Instead, you need to enter the IP address and port
+number of the Tvheadend web interface.  For example
+```1.2.3.4:9981```.  If the media player does not
+support manually entering details then it is not
+supported.
+
+Typically the media player will then ask for xmltv
+details to populate the TV Guide.  This can normally
+be retrieved from Tvheadend via the web interface.
+For example ```http://1.2.3.4:9981/xmltv/channels```.

--- a/src/config.c
+++ b/src/config.c
@@ -2085,6 +2085,7 @@ PROP_DOC(config_channelicon_path)
 PROP_DOC(config_channelname_scheme)
 PROP_DOC(config_picon_path)
 PROP_DOC(config_picon_servicetype)
+PROP_DOC(config_hdhomerun_server_username)
 PROP_DOC(viewlevel_config)
 PROP_DOC(themes)
 
@@ -2505,6 +2506,93 @@ const idclass_t config_class = {
                    "and tuner 3 will talk to port 9986."),
       .off    = offsetof(config_t, local_port),
       .opts   = PO_HIDDEN | PO_EXPERT,
+      .group  = 6
+    },
+    {
+      .type   = PT_STR,
+      .id     = "hdhomerun_server_username",
+      .name   = N_("Tvheadend username for HDHomeRun Server Emulation"),
+      .desc   = N_("When Tvheadend is acting as an HDHomeRun Server "
+                   "(emulating an HDHomeRun device for downstream "
+                   "media devices to stream Live TV) then "
+                   "we use this user for determining permissions "
+                   "such as channels that can be streamed.  "
+                   "This user must have basic streaming permissions.  "
+                   "This user must also have persistent "
+                   "authentication enabled in the user password settings.  "
+                   "It is strongly recommended that IP Blocking is used to "
+                   "prevent access from outside your network."
+                  ),
+      .doc    = prop_doc_config_hdhomerun_server_username,
+      .off    = offsetof(config_t, hdhomerun_server_username),
+      .opts   = PO_EXPERT
+#if !ENABLE_HDHOMERUN_SERVER
+      | PO_PHIDDEN
+#endif
+      ,
+      .group  = 6,
+    },
+    {
+      .type   = PT_U32,
+      .id     = "hdhomerun_server_tuner_count",
+      .name   = N_("Number of tuners to export for HDHomeRun Server Emulation"),
+      .desc   = N_("When Tvheadend is acting as an HDHomeRun Server "
+                   "(emulating an HDHomeRun device for downstream "
+                   "media devices to stream Live TV) then "
+                   "we tell clients that we have this number of tuners. "
+                   "This is necessary since some clients artificially limit "
+                   "connections based on tuner count, even though several "
+                   "channels may share a multiplex on one tuner. "
+                   "The HDHomeRun interface can not distinguish between "
+                   "different types of tuner in a mixed system with "
+                   "satellite, aerial and cable. "
+                   "The actual number or types of tuners used by Tvheadend is "
+                   "not affected by this value.  Tvheadend will "
+                   "allocate tuners automatically.  "
+                   "Set to zero for Tvheadend to use a default value."
+                  ),
+      .off    = offsetof(config_t, hdhomerun_server_tuner_count),
+      .opts   = PO_EXPERT
+#if !ENABLE_HDHOMERUN_SERVER
+      | PO_PHIDDEN
+#endif
+      ,
+      .group  = 6,
+    },
+    {
+      .type   = PT_STR,
+      .id     = "hdhomerun_server_model_name",
+      .name   = N_("Tvheadend model name for HDHomeRun Server Emulation"),
+      .desc   = N_("When Tvheadend is acting as an HDHomeRun Server "
+                   "(emulating an HDHomeRun device for downstream "
+                   "media devices to stream Live TV) then "
+                   "we use this as the type of HDHomeRun model number "
+                   "that we send to clients.  Some clients may require "
+                   "a specific model number to work.  Leave blank "
+                   "for Tvheadend to use a default."
+                  ),
+      .off    = offsetof(config_t, hdhomerun_server_model_name),
+      .opts   = PO_EXPERT
+#if !ENABLE_HDHOMERUN_SERVER
+      | PO_PHIDDEN
+#endif
+      ,
+      .group  = 6,
+    },
+    {
+      .type   = PT_BOOL,
+      .id     = "hdhomerun_server_enable",
+      .name   = N_("Enable HDHomeRun Server Emulation"),
+      .desc   = N_("Enable the Tvheadend server to emulate "
+                   "an HDHomeRun server.  This allows LiveTV "
+                   "to be used on some media servers."
+                  ),
+      .off    = offsetof(config_t, hdhomerun_server_enable),
+      .opts   = PO_EXPERT
+#if !ENABLE_HDHOMERUN_SERVER
+      | PO_PHIDDEN
+#endif
+,
       .group  = 6
     },
     {

--- a/src/config.h
+++ b/src/config.h
@@ -74,6 +74,10 @@ typedef struct config {
   char *hdhomerun_ip;
   char *local_ip;
   int local_port;
+  char *hdhomerun_server_username;
+  uint32_t hdhomerun_server_tuner_count;
+  char *hdhomerun_server_model_name;
+  int hdhomerun_server_enable;
 } config_t;
 
 extern const idclass_t config_class;

--- a/src/htsmsg.h
+++ b/src/htsmsg.h
@@ -214,6 +214,13 @@ void htsmsg_add_str_alloc(htsmsg_t *msg, const char *name, char *str);
 void htsmsg_add_str_exclusive(htsmsg_t *msg, const char *str);
 
 /**
+ * Add a string using printf-style for the value.
+ */
+void
+htsmsg_add_str_printf(htsmsg_t *msg, const char *name, const char *fmt, ...)
+  __attribute__((format(printf,3,4)));;
+
+/**
  * Add/update a string field
  */
 int  htsmsg_set_str(htsmsg_t *msg, const char *name, const char *str);

--- a/src/htsmsg_json.h
+++ b/src/htsmsg_json.h
@@ -29,6 +29,7 @@ htsmsg_t *htsmsg_json_deserialize(const char *src);
 
 void htsmsg_json_serialize(htsmsg_t *msg, htsbuf_queue_t *hq, int pretty);
 
+__attribute__((warn_unused_result))
 char *htsmsg_json_serialize_to_str(htsmsg_t *msg, int pretty);
 
 struct rstr *htsmsg_json_serialize_to_rstr(htsmsg_t *msg, const char *prefix);


### PR DESCRIPTION
We now offer the ability to pretend to be an HDHomeRun server
to expose channels for LiveTV.  DVR functionality is not
exposed.

This only works on media players that allow IP:Port
number configuration.  It is hooked in to the webui
and only exists if the feature is compiled in and
explicitly enabled in the GUI.

To use:

- Add a user and enable persistent authentication via
  Config->User->Passwords->Persistent Authentication Enable.

- Use this user for the HDHomeRun server setup in
  Config->General->Base->HDHomeRun/Local Username.

Then manually add the device to your client using the
IP address and port of the TVHeadend server, such as
192.168.0.1:9981

Auto-discovery of the TVHeadend server by downstream
media clients does not work since clients seem to use
different mechanisms.

So, although many clients (such as TVHeadend) use
a broadcast at 65001 to locate clients, one of
the popular media players does not use this mechanism.

The persistent authentication allows the client to stream
LiveTV from the TVHeadend server using the credentials for
the given user.  Using a user allows us to do filtering
such as only allowing specific channels to be passed
through to the downstream clients.

For "DeviceAuth" we use a (hard-coded) randomly generated
value since it has to be 24 lowercase/digit characters long.

For DeviceID, we base it on the server name.  Technically
a DeviceID needs to match a particular format to validate
against a CRC, but no clients seems to enforce this.

The feature is configurable.  If the feature is disabled
then we hide the options in the GUI rather than compile
them out completely.  This ensures that if the user
accidentally compiles with the options disabled
then they will not lose their configuration.

Issue: #4461